### PR TITLE
added DDLambda.metric() - function with own date

### DIFF
--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -95,6 +95,18 @@ public class DDLambda {
     }
 
     /**
+     * metric allows the user to record their own custom metric that will be sent to Datadog.
+     * also allows user to set his/her own date.
+     * @param name The metric's name
+     * @param value The metric's value
+     * @param tags A map of tags to be assigned to the metric
+     * @param date The date under which the metric value will appear in datadog
+     */
+    public void metric(String name, double value, Map<String, Object> tags, Date date){
+        new CustomMetric(name, value, tags, date).write();
+    }
+
+    /**
      * error increments the aws.lambda.enhanced.error metric in Datadog.
      * @param cxt The AWS Context provided to your handler
      */

--- a/src/test/java/com/datadoghq/datadog_lambda_java/LambdaInstrumenterTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/LambdaInstrumenterTest.java
@@ -1,5 +1,7 @@
 package com.datadoghq.datadog_lambda_java;
 
+import java.util.Date;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.gson.Gson;
 import org.junit.After;
@@ -70,6 +72,25 @@ public class LambdaInstrumenterTest {
         PersistedCustomMetric pcm = g.fromJson(omw.CM.toJson(), PersistedCustomMetric.class);
         Assert.assertEquals("my_custom_metric", pcm.metric);
         Assert.assertEquals(Double.valueOf(37.1), pcm.value);
+    }
+
+    @Test public void TestLambdaInstrumentorCustomMetricWithDate(){
+        ObjectMetricWriter omw = new ObjectMetricWriter();
+        MetricWriter.setMetricWriter(omw);
+
+        Date date = new Date();
+        date.setTime(1590420166419L);
+        DDLambda li =new DDLambda(null);
+
+        li.metric("my_custom_metric", 37.1, null, date);
+        Assert.assertNotNull(omw.CM);
+
+        Gson g = new Gson();
+        PersistedCustomMetric pcm = g.fromJson(omw.CM.toJson(), PersistedCustomMetric.class);
+        Assert.assertEquals("my_custom_metric", pcm.metric);
+        Assert.assertEquals(Double.valueOf(37.1), pcm.value);
+        Assert.assertEquals(Double.valueOf(37.1), pcm.value);
+        Assert.assertEquals(1590420166, pcm.eventTime);
     }
 
     @Test public void TestLambdaInstrumentorCountsColdStartErrors(){


### PR DESCRIPTION
Since the CustomMetric class already supports an own Date in a second constructor, I added the corresponding DDLambda.metric() function passing through a Date object