### PR TITLE
Chris.agocs/compile for java 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Include the following dependency in your `pom.xml`
 <dependency>
 	<groupId>com.datadoghq</groupId>
 	<artifactId>datadog-lambda-java</artifactId>
-	<version>0.0.3</version>
+	<version>0.0.4</version>
 	<type>pom</type>
 </dependency>
 ```
@@ -48,7 +48,7 @@ repositories {
 }
 
 dependencies {
-     implementation 'com.datadoghq:datadog-lambda-java:0.0.3'
+     implementation 'com.datadoghq:datadog-lambda-java:0.0.4'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,11 @@ dependencies {
     implementation 'org.jetbrains:annotations:15.0'
 }
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 group = 'com.datadoghq'
-version = '0.0.3'
+version = '0.0.4'
 
 allprojects {
     repositories {
@@ -51,14 +54,14 @@ publishing {
             from components.java
             groupId 'com.datadoghq'
             artifactId 'datadog-lambda-java'
-            version '0.0.3'
+            version '0.0.4'
         }
     }
 }
 
 bintray {
-    user = System.getenv('BINTRAY_USER') 
-    key = System.getenv('BINTRAY_API_TOKEN') 
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_TOKEN')
     publications = ['MyPublication']
     pkg {
         repo = 'datadog-maven'
@@ -67,9 +70,9 @@ bintray {
         licenses = ['Apache-2.0']
         vcsUrl = 'https://github.com/DataDog/datadog-lambda-java.git'
         version {
-            name = '0.0.3'
+            name = '0.0.4'
             desc = 'Datadog Lambda Java runtime library'
-            vcsTag = '0.0.3'
+            vcsTag = '0.0.4'
             attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
         }
     }


### PR DESCRIPTION
### What does this PR do?

Bumps the release version to 0.0.4 because the 0.0.3 artifact was compiled for Java 1.12

Fixes #13 
