### PR TITLE
Add trace log correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Slack](https://img.shields.io/badge/slack-%23serverless-blueviolet?logo=slack)](https://datadoghq.slack.com/channels/serverless/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DataDog/datadog-lambda-java/blob/master/LICENSE)
 ![](https://github.com/DataDog/datadog-lambda-java/workflows/Test%20on%20Master%20branch/badge.svg)
+![Bintray](https://img.shields.io/bintray/v/datadog/datadog-maven/datadog-lambda-java)
 
 The Datadog Lambda Java Client Library for Java (8 and 11) enables [enhanced lambda metrics](https://docs.datadoghq.com/integrations/amazon_lambda/?tab=awsconsole#real-time-enhanced-lambda-metrics) 
 and [distributed tracing](https://docs.datadoghq.com/integrations/amazon_lambda/?tab=awsconsole#tracing-with-datadog-apm) 

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ If you are using JSON logs, add the trace ID and span ID to each log message wit
 #### Plain text logs
 
 If you are using plain text logs, then you must create a new [Parser](https://docs.datadoghq.com/logs/processing/parsing/?tab=matcher)
-that can extract the trace context from the correct position in the logs. Use the helper `_trace_context` to
-extract the trace context. For example, if your log line looked like:
+by cloning the existing Lambda Pipeline. The new parser can extract the trace context from the correct position in the logs. 
+Use the helper `_trace_context` to extract the trace context. For example, if your log line looked like:
 
 ```
 INFO 2020-11-11T14:00:00Z LAMBDA_REQUEST_ID [dd.trace_id=12345 dd.span_id=67890] This is a log message

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once [installed](#installation), you should be able to submit custom metrics fro
 
 Check out the instructions for [submitting custom metrics from AWS Lambda functions](https://docs.datadoghq.com/integrations/amazon_lambda/?tab=java#custom-metrics).
 
-## Tracing
+## Distributed Tracing
 
 Wrap your outbound HTTP requests with trace headers to see your lambda in context in APM.
 The Lambda Java Client Library provides instrumented HTTP connection objects as well as helper methods for
@@ -167,6 +167,30 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
     }
 }
 ```
+
+### Trace/Log Correlations
+
+In order to correlate your traces with your logs, you must inject the Trace ID (Datadog or XRay)
+into your log messages. We've added the Trace ID into the slf4j MDC under the key `dd.trace_id`
+and provided convenience methods to get it automatically. The Trace ID is added to the MDC as a side
+effect of instantiating any `new DDLambda(...)`.
+
+If you are using JSON logs, add the trace ID to each log message with the key `dd.trace_id`. 
+
+If you are using plain text logs, then you must create a new [Parser](https://docs.datadoghq.com/logs/processing/parsing/?tab=matcher)
+that can extract the trace ID from the correct position in the logs. Please see below about how
+to access the Trace ID.
+
+#### Log4j / SLF4J
+
+We have added the Trace ID into the slf4j MDC under the key `dd.trace_id`. If you are, for example,
+using a `PatternLayout`, you must add the pattern `%X{dd.trace_id}` into your layout.
+
+#### Other logging solutions
+
+If you are using a different logging solution, the trace ID can be accessed using the method
+`DDLambda.getTraceLogCorrelationId()`. That returns your trace ID as a string that can be added
+to any log message.
 
 ## Opening Issues
 

--- a/README.md
+++ b/README.md
@@ -201,14 +201,19 @@ my_custom_rule \[%{word:level}\]?\s+%{_timestamp}\s+%{notSpace:lambda.request_id
 
 #### Log4j / SLF4J
 
-We have added the Trace ID into the slf4j MDC under the key `dd.trace_context`. If you are, for example,
-using a `PatternLayout`, you must add the pattern `%X{dd.trace_context}` into your layout. E.g.
+We have added the Trace ID into the slf4j MDC under the key `dd.trace_context`. That can be accessed
+using the `%X{dd.trace_context}` operator. Here is an example `log4j.properties`: 
 
 ```
-PatternLayout layout = new PatternLayout("%-5p [%t]: %m %X{dd.trace_context}%n");
+log = .
+log4j.rootLogger = DEBUG, LAMBDA
+
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %X{dd.trace_context} %-5p %c:%L - %m%n
 ```
 
-would result in log lines looking like `DEBUG [main]: This is a log message [dd.trace_id=12345 dd.span_id=67890]`
+would result in log lines looking like `2020-11-13 19:21:53 [dd.trace_id=1168910694192328743 dd.span_id=3204959397041471598] INFO  com.serverless.Handler:20 - Test Log Message`
 
 #### Other logging solutions
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version = '0.0.6'
+version= '0.0.6'
 
 allprojects {
     repositories {
@@ -56,7 +56,7 @@ publishing {
             from components.java
             groupId 'com.datadoghq'
             artifactId 'datadog-lambda-java'
-            version version
+            version project.version.toString()
         }
     }
 }
@@ -72,14 +72,14 @@ bintray {
         licenses = ['Apache-2.0']
         vcsUrl = 'https://github.com/DataDog/datadog-lambda-java.git'
         version {
-            name = version
+            name = project.version.toString()
             desc = 'Datadog Lambda Java runtime library'
-            vcsTag = version
+            vcsTag = project.version.toString()
             attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
         }
     }
 }
 
 buildConfig {
-    buildConfigField('String', 'datadog_lambda_version', '"' + version + '"')
+    buildConfigField('String', 'datadog_lambda_version', '"' + project.version.toString() + '"')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.0.6'
+version= '0.0.7'
 
 allprojects {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,13 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.11'
     implementation 'com.squareup.okhttp3:okhttp:4.4.0'
     implementation 'org.apache.commons:commons-lang3:3.10'
-
+    implementation 'org.slf4j:slf4j-log4j12:1.7.28'
+    implementation 'org.jetbrains:annotations:15.0'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
-    implementation 'org.jetbrains:annotations:15.0'
+    testImplementation 'org.apache.logging.log4j:log4j-api:2.13.3'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.13.3'
 }
 
 sourceCompatibility = 1.8

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -21,6 +21,7 @@ public class DDLambda {
     private String ENHANCED_PREFIX = "aws.lambda.enhanced.";
     private String INVOCATION = "invocations";
     private String ERROR = "errors";
+    private String MDC_TRACE_ID_FIELD = "dd.trace_id";
     private Tracing tracing;
     private boolean enhanced = true;
 
@@ -32,7 +33,7 @@ public class DDLambda {
         this.tracing = new Tracing();
         this.enhanced = checkEnhanced();
         recordEnhanced(INVOCATION, cxt);
-        MDC.put("trace_id", getTraceLogCorrelationId());
+        MDC.put(MDC_TRACE_ID_FIELD, getTraceLogCorrelationId());
     }
 
     /**
@@ -44,7 +45,7 @@ public class DDLambda {
         this.tracing = new Tracing(xrayTraceInfo);
         this.enhanced = checkEnhanced();
         recordEnhanced(INVOCATION, cxt);
-        MDC.put("trace_id", getTraceLogCorrelationId());
+        MDC.put(MDC_TRACE_ID_FIELD, getTraceLogCorrelationId());
     }
 
     /**
@@ -58,7 +59,7 @@ public class DDLambda {
         recordEnhanced(INVOCATION, cxt);
         this.tracing = new Tracing(req);
         this.tracing.submitSegment();
-        MDC.put("trace_id", getTraceLogCorrelationId());
+        MDC.put(MDC_TRACE_ID_FIELD, getTraceLogCorrelationId());
     }
 
     /**
@@ -72,7 +73,7 @@ public class DDLambda {
         recordEnhanced(INVOCATION, cxt);
         this.tracing = new Tracing(req);
         this.tracing.submitSegment();
-        MDC.put("trace_id", getTraceLogCorrelationId());
+        MDC.put(MDC_TRACE_ID_FIELD, getTraceLogCorrelationId());
     }
 
     /**
@@ -86,7 +87,7 @@ public class DDLambda {
         recordEnhanced(INVOCATION, cxt);
         this.tracing = new Tracing(req);
         this.tracing.submitSegment();
-        MDC.put("trace_id", getTraceLogCorrelationId());
+        MDC.put(MDC_TRACE_ID_FIELD, getTraceLogCorrelationId());
     }
 
     private boolean checkEnhanced(){

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -16,6 +16,9 @@ public class Tracing {
     protected DDTraceContext cxt;
     protected XRayTraceContext xrt;
 
+    protected String TRACE_ID_KEY = "dd.trace_id";
+    protected String SPAN_ID_KEY = "dd.span_id";
+
     public Tracing(){
         this.xrt = new XRayTraceContext();
     }
@@ -58,15 +61,29 @@ public class Tracing {
         return xrt;
     }
 
-    public String getLogCorrelationTraceID(){
+    public Map<String,String> getLogCorrelationTraceAndSpanIDsMap(){
         if (this.cxt != null){
-            return this.cxt.getTraceID();
+            String traceID = this.cxt.getTraceID();
+            String spanID = this.cxt.getParentID();
+            Map<String, String> out  = new HashMap<String, String>();
+            out.put(TRACE_ID_KEY, traceID);
+            out.put(SPAN_ID_KEY, spanID);
+            return out;
         }
         if (this.xrt != null){
-            return this.xrt.getAPMTraceID();
+            String traceID = this.xrt.getAPMTraceID();
+            String spanID = this.xrt.getAPMParentID();
+            Map<String, String> out  = new HashMap<String, String>();
+            out.put(TRACE_ID_KEY, traceID);
+            out.put(SPAN_ID_KEY, spanID);
+            return out;
         }
         DDLogger.getLoggerImpl().debug("No DD trace context or XRay trace context set!");
-        return "";
+        return null;
+    }
+
+    private String formatLogCorrelation(String trace, String span){
+        return String.format("[dd.trace_id=%s dd.span_id=%s]", trace, span);
     }
 
     private static DDTraceContext populateDDContext(Map<String,String> headers){

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -337,7 +337,7 @@ class XRayTraceContext{
         //Root=1-5e41a79d-e6a0db584029dba86a594b7e;Parent=8c34f5ad8f92d510;Sampled=1
         String traceId = System.getenv("_X_AMZN_TRACE_ID");
         if (traceId == null || traceId == ""){
-            DDLogger.getLoggerImpl().error("Unable to find _X_AMZN_TRACE_ID");
+            DDLogger.getLoggerImpl().debug("Unable to find _X_AMZN_TRACE_ID");
             return;
         }
         String[] traceParts = traceId.split(";");
@@ -363,7 +363,7 @@ class XRayTraceContext{
     protected XRayTraceContext(String traceId){
         String[] traceParts = traceId.split(";");
         if(traceParts.length != 3){
-            DDLogger.getLoggerImpl().error ("Malformed _X_AMZN_TRACE_ID value: "+ traceId);
+            DDLogger.getLoggerImpl().error("Malformed _X_AMZN_TRACE_ID value: "+ traceId);
             return;
         }
 
@@ -423,13 +423,13 @@ class XRayTraceContext{
             bigid = this.traceId.split("-")[2];
         }
         catch (ArrayIndexOutOfBoundsException | NullPointerException ai){
-            DDLogger.getLoggerImpl().error("Unexpected format for the trace ID. Unable to parse it. " + this.traceId);
+            DDLogger.getLoggerImpl().debug("Unexpected format for the trace ID. Unable to parse it. " + this.traceId);
             return "";
         }
 
         //just to verify
         if (bigid.length() != 24){
-            DDLogger.getLoggerImpl().error("Got an unusual traceid from x-ray. Unable to convert that to an APM id. " + this.traceId);
+            DDLogger.getLoggerImpl().debug("Got an unusual traceid from x-ray. Unable to convert that to an APM id. " + this.traceId);
             return "";
         }
 
@@ -440,7 +440,7 @@ class XRayTraceContext{
             parsed = Long.parseUnsignedLong(last16, 16); //unsigned because parseLong throws a numberformatexception at anything greater than 0x7FFFF...
         }
         catch (NumberFormatException ne){
-            DDLogger.getLoggerImpl().error("Got a NumberFormatException trying to parse the traceID. Unable to convert to an APM id. " + this.traceId);
+            DDLogger.getLoggerImpl().debug("Got a NumberFormatException trying to parse the traceID. Unable to convert to an APM id. " + this.traceId);
             return "";
         }
         parsed = parsed & 0x7FFFFFFFFFFFFFFFL; //take care of that pesky first bit...

--- a/src/test/java/com/datadoghq/datadog_lambda_java/TraceLogCorrelationTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/TraceLogCorrelationTest.java
@@ -1,0 +1,49 @@
+package com.datadoghq.datadog_lambda_java;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.Assert;
+import org.junit.Test;
+import org.apache.log4j.Logger;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.WriterAppender;
+import org.apache.log4j.PatternLayout;
+
+
+public class TraceLogCorrelationTest {
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalErr = System.err;
+
+    @Test
+    public void TestWithLog4J(){
+        Logger logger = Logger.getLogger(TraceLogCorrelationTest.class.getName());
+        PatternLayout layout = new PatternLayout("%d{ISO8601} %X{trace_id} [%t] %-5p %c %x - %m%n");
+        logger.addAppender(new ConsoleAppender((layout)));
+
+        logger.info("Test log message");
+
+        EnhancedMetricTest.MockContext mc = new EnhancedMetricTest.MockContext();
+
+        //try to grab the contents of StdErr
+        logger.addAppender(new WriterAppender(layout, outContent));
+        DDLambda ddl = new DDLambda(mc, "Root=1-5fa98677-5dda00b12ec8b1c31f61aa82;Parent=b481b4a6ef3a296c;Sampled=1");
+        outContent.reset();
+        logger.info("Test log message 2");
+        logger.removeAllAppenders();
+
+        String logOutput  = outContent.toString();
+        String[] logFields = logOutput.split(" ");
+        Assert.assertEquals("3371139772690049666", logFields[2]);
+    }
+
+    @Test
+    public void TestGetTraceLogCorrelationId(){
+        EnhancedMetricTest.MockContext mc = new EnhancedMetricTest.MockContext();
+        DDLambda ddl = new DDLambda(mc, "Root=1-5fa98677-5dda00b12ec8b1c31f61aa82;Parent=b481b4a6ef3a296c;Sampled=1");
+
+        String ddLogId = ddl.getTraceLogCorrelationId();
+        Assert.assertEquals("3371139772690049666", ddLogId);
+    }
+
+}
+

--- a/src/test/java/com/datadoghq/datadog_lambda_java/TraceLogCorrelationTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/TraceLogCorrelationTest.java
@@ -17,7 +17,7 @@ public class TraceLogCorrelationTest {
     @Test
     public void TestWithLog4J(){
         Logger logger = Logger.getLogger(TraceLogCorrelationTest.class.getName());
-        PatternLayout layout = new PatternLayout("%d{ISO8601} %X{trace_id} [%t] %-5p %c %x - %m%n");
+        PatternLayout layout = new PatternLayout("%d{ISO8601} %X{dd.trace_id} [%t] %-5p %c %x - %m%n");
         logger.addAppender(new ConsoleAppender((layout)));
 
         logger.info("Test log message");

--- a/src/test/java/com/datadoghq/datadog_lambda_java/TraceLogCorrelationTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/TraceLogCorrelationTest.java
@@ -2,6 +2,7 @@ package com.datadoghq.datadog_lambda_java;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.apache.log4j.Logger;
@@ -17,7 +18,7 @@ public class TraceLogCorrelationTest {
     @Test
     public void TestWithLog4J(){
         Logger logger = Logger.getLogger(TraceLogCorrelationTest.class.getName());
-        PatternLayout layout = new PatternLayout("%d{ISO8601} %X{dd.trace_id} [%t] %-5p %c %x - %m%n");
+        PatternLayout layout = new PatternLayout("%d{ISO8601} %X{dd.trace_context} [%t] %-5p %c %x - %m%n");
         logger.addAppender(new ConsoleAppender((layout)));
 
         logger.info("Test log message");
@@ -33,7 +34,8 @@ public class TraceLogCorrelationTest {
 
         String logOutput  = outContent.toString();
         String[] logFields = logOutput.split(" ");
-        Assert.assertEquals("3371139772690049666", logFields[2]);
+        Assert.assertEquals("[dd.trace_id=3371139772690049666", logFields[2]);
+        Assert.assertEquals("dd.span_id=13006875827893840236]", logFields[3]);
     }
 
     @Test
@@ -41,8 +43,9 @@ public class TraceLogCorrelationTest {
         EnhancedMetricTest.MockContext mc = new EnhancedMetricTest.MockContext();
         DDLambda ddl = new DDLambda(mc, "Root=1-5fa98677-5dda00b12ec8b1c31f61aa82;Parent=b481b4a6ef3a296c;Sampled=1");
 
-        String ddLogId = ddl.getTraceLogCorrelationId();
-        Assert.assertEquals("3371139772690049666", ddLogId);
+        Map<String,String> traceInfo = ddl.getTraceContext();
+        Assert.assertEquals("3371139772690049666", traceInfo.get("dd.trace_id"));
+        Assert.assertEquals("13006875827893840236", traceInfo.get("dd.span_id"));
     }
 
 }

--- a/src/test/java/com/datadoghq/datadog_lambda_java/XRayTraceContextTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/XRayTraceContextTest.java
@@ -23,16 +23,48 @@ public class XRayTraceContextTest {
 
 
     @Test
-    public void getAPMParentFromXray_bad_characters(){
+    public void getAPMParentFromXray_bad_characters() {
         XRayTraceContext xrt = new XRayTraceContext();
         xrt.setParentId(";79014b90ce44db5e0;875");
         Assert.assertNull(xrt.getAPMParentID());
     }
 
     @Test
-    public void getAPMParentFromXray_too_short(){
+    public void getAPMParentFromXray_too_short() {
         XRayTraceContext xrt = new XRayTraceContext();
         xrt.setParentId("875");
         Assert.assertNull(xrt.getAPMParentID());
+    }
+
+    @Test
+    public void getAPMTraceID() {
+        XRayTraceContext xrt = new XRayTraceContext();
+        xrt.setTraceId("1-5ce31dc2-2c779014b90ce44db5e03875");
+        String traceId = xrt.getAPMTraceID();
+        Assert.assertEquals("4110911582297405557", traceId);
+    }
+
+    @Test
+    public void getAPMTraceID_too_short() {
+        XRayTraceContext xrt = new XRayTraceContext();
+        xrt.setTraceId("1-5ce31dc2-5e03875");
+        String traceId = xrt.getAPMTraceID();
+        Assert.assertEquals("", traceId);
+    }
+
+    @Test
+    public void getAPMTraceID_invalid_format() {
+        XRayTraceContext xrt = new XRayTraceContext();
+        xrt.setTraceId("1-2c779014b90ce44db5e03875");
+        String traceId = xrt.getAPMTraceID();
+        Assert.assertEquals("", traceId);
+    }
+
+    @Test
+    public void getAPMTraceID_incorrect_characters() {
+        XRayTraceContext xrt = new XRayTraceContext();
+        xrt.setTraceId("1-5ce31dc2-c779014b90ce44db5e03875;");
+        String traceId = xrt.getAPMTraceID();
+        Assert.assertEquals("", traceId);
     }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This adds the capability to inject trace IDs into your logs so that you can correlate your logs with your traces.

In the case of XRay tracing, this calculates a DD Trace ID from the last 63 bits of the XRay trace ID. It exposes a method from within DDLambda that lets you get your trace ID. It also adds the trace ID to the slf4j [MDC](http://www.slf4j.org/manual.html#mdc) so that the trace ID can be accessed by Log4J or other logging frameworks. 

### Testing Guidelines

Done: Unit tests that instantiate a new DDLambda (w/XRay tracing) and attempt to log some things using Log4J, verifying that the trace ID was added to the logs. Created a test lambda using log4j and verified it worked as expected.


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [xc] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
