### PR TITLE
change == to .equals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.apache.logging.log4j:log4j-api:2.13.3'
     testImplementation 'org.apache.logging.log4j:log4j-core:2.13.3'
+    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
 }
 
 sourceCompatibility = 1.8

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -90,7 +90,7 @@ public class DDLambda {
         MDC.put(MDC_TRACE_CONTEXT_FIELD, getTraceContextString());
     }
 
-    private boolean checkEnhanced(){
+    protected boolean checkEnhanced(){
         String sysEnhanced = System.getenv(ENHANCED_ENV);
         if (sysEnhanced == null){
             return true;

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -96,7 +96,7 @@ public class DDLambda {
             return true;
         }
 
-        if (sysEnhanced.toLowerCase() == "false"){
+        if (sysEnhanced.toLowerCase().equals("false")){
             return false;
         }
         return true;

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -191,7 +191,7 @@ class ConverterSubsegment {
     }
 
     public boolean sendToXRay(){
-        if (this.id == null || this.id == "") {
+        if (this.id == null || this.id.equals("")) {
             return false;
         }
 
@@ -353,7 +353,7 @@ class XRayTraceContext{
     public XRayTraceContext(){
         //Root=1-5e41a79d-e6a0db584029dba86a594b7e;Parent=8c34f5ad8f92d510;Sampled=1
         String traceId = System.getenv("_X_AMZN_TRACE_ID");
-        if (traceId == null || traceId == ""){
+        if (traceId == null || traceId.equals("")){
             DDLogger.getLoggerImpl().debug("Unable to find _X_AMZN_TRACE_ID");
             return;
         }

--- a/src/test/java/com/datadoghq/datadog_lambda_java/LambdaInstrumenterTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/LambdaInstrumenterTest.java
@@ -8,9 +8,14 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 
 public class LambdaInstrumenterTest {
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     @Before
     public void setUp() throws Exception {
         ColdStart.resetColdStart();
@@ -107,6 +112,35 @@ public class LambdaInstrumenterTest {
         Assert.assertEquals("aws.lambda.enhanced.errors", pcm.metric);
 
         Assert.assertTrue(pcm.tags.contains("cold_start:true"));
+    }
+
+    @Test
+    public void EnhancedMetricsDeactivatedWithEnvVar(){
+        environmentVariables.set("DD_ENHANCED_METRICS", "false");
+        Context mc1 = new EnhancedMetricTest.MockContext();
+        DDLambda ddl = new DDLambda(mc1);
+        boolean isEnhanced = ddl.checkEnhanced();
+        Assert.assertFalse(isEnhanced);
+        environmentVariables.clear("DD_ENHANCED_METRICS");
+    }
+
+    @Test
+    public void EnhancedMetricsActivatedByDefault(){
+        System.out.println(System.getenv("DD_ENHANCED_METRICS"));
+        Context mc1 = new EnhancedMetricTest.MockContext();
+        DDLambda ddl = new DDLambda(mc1);
+        boolean isEnhanced = ddl.checkEnhanced();
+        Assert.assertTrue(isEnhanced);
+    }
+
+    @Test
+    public void EnhancedMetricsActivatedWithEnvVar(){
+        environmentVariables.set("DD_ENHANCED_METRICS", "true");
+        Context mc1 = new EnhancedMetricTest.MockContext();
+        DDLambda ddl = new DDLambda(mc1);
+        boolean isEnhanced = ddl.checkEnhanced();
+        Assert.assertTrue(isEnhanced);
+        environmentVariables.clear("DD_ENHANCED_METRICS");
     }
 
     @After


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

I found three instances where I was performing a string comparison using `==` and I should have been using `.equals`. The two in Tracing.java are mostly harmless, but the one in DDLambda.java was preventing users from being able to disable enhanced metrics. This PR fixes those three instances.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

A customer reached out to support about this.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Wrote unit tests to verify the behavior of `checkEnhanced`

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
