### PR TITLE
Fix distributed tracing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.0.10-beta5'
+version= '0.0.10-beta6'
 
 allprojects {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.0.11'
+version= '0.0.10'
 
 allprojects {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.0.10-beta6'
+version= '0.0.11'
 
 allprojects {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.0.9'
+version= '0.0.10-beta5'
 
 allprojects {
     repositories {

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -122,7 +122,7 @@ public class DDLambda {
      * @param cxt is the Lambda Context passed to the Handler function.
      */
     private void startSpan(Map<String,String> headers, Context cxt){
-        //If the user has set DD_TRACE_ENABLED=false, don't start a span
+        //If the user has not set DD_TRACE_ENABLED=true, don't start a span
         if(!checkTraceEnabled()){
             return;
         }

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -1,5 +1,6 @@
 package com.datadoghq.datadog_lambda_java;
 
+import io.opentracing.Scope;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import java.io.IOException;
@@ -32,6 +33,7 @@ public class DDLambda {
     private String JSON_SPAN_ID = "dd.span_id";
     private Tracing tracing;
     private boolean enhanced = true;
+    private Scope tracingScope;
 
     /**
      * Create a new DDLambda instrumenter given some Lambda context
@@ -131,7 +133,7 @@ public class DDLambda {
         }
         Span thisSpan = spanBuilder.start();
         System.out.println("Started span "+ thisSpan);
-        tracer.activateSpan(thisSpan);
+        this.tracingScope = tracer.activateSpan(thisSpan);
         System.out.println("Activated span " + thisSpan);
     }
 
@@ -143,12 +145,21 @@ public class DDLambda {
     public void finish(){
         System.out.println("AGOCS -- finishing span");
         Span span = GlobalTracer.get().activeSpan();
-        System.out.println("Got active span " + span);
+
+
+
+        System.out.println("Got active span to finish" + span);
         if (span != null) {
             span.finish();
         } else {
             System.out.println("AGOCS -- Span was null");
         }
+
+
+        if (this.tracingScope == null){
+            System.out.println("AGOCS -- scope is null!!");
+        }
+        this.tracingScope.close();
     }
 
 

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -1,19 +1,17 @@
 package com.datadoghq.datadog_lambda_java;
 
-import io.opentracing.SpanContext;
 import java.io.IOException;
 import java.net.*;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Random;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2ProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.google.gson.Gson;
 
-public class Tracing implements SpanContext {
+public class Tracing{
 
     protected DDTraceContext cxt;
     protected XRayTraceContext xrt;
@@ -131,33 +129,6 @@ public class Tracing implements SpanContext {
         traceHeaders.put(this.cxt.ddParentKey, this.xrt.getAPMParentID());
 
         return traceHeaders;
-    }
-
-    @Override
-    public String toTraceId() {
-        if (this.cxt != null){
-            return this.cxt.getTraceID();
-        }
-        if (this.xrt != null){
-            return this.xrt.getAPMTraceID();
-        }
-        return null;
-    }
-
-    @Override
-    public String toSpanId() {
-        if (this.cxt != null){
-            return this.cxt.getParentID();
-        }
-        if (this.xrt != null){
-            return this.xrt.getAPMParentID();
-        }
-        return null;
-    }
-
-    @Override
-    public Iterable<Entry<String, String>> baggageItems() {
-        return null;
     }
 }
 
@@ -319,11 +290,6 @@ class DDTraceContext {
         }
         headers = toLowerKeys(headers);
 
-        System.out.println("AGOCS -- Headers has been converted to lower case");
-        for ( Map.Entry<String, String> entry: headers.entrySet()) {
-            System.out.println(entry.getKey() + " : " + entry.getValue());
-        }
-
         if (headers.get(ddTraceKey) == null) {
             DDLogger.getLoggerImpl().debug("Headers missing the DD Trace ID");
             throw new Exception("No trace ID");
@@ -341,8 +307,6 @@ class DDTraceContext {
             headers.put(ddSamplingKey, "2");
         }
         this.samplingPriority = headers.get(ddSamplingKey);
-
-        System.out.println("Agocs: Set trace id to: " + this.getTraceID());
     }
 
     private  Map<String,String> toLowerKeys(Map<String,String> headers){


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This provides methods for getting the datadog trace and span ID from incoming request headers and setting them inside dd-agent-java attached to the JVM. Specifically:

- in DDLambda.java, I've added `startSpan`. `startSpan` uses the OpenTracing API to communicate with dd-agent-java to start a new span. If the appropriate headers are set on the request, `startSpan` packages that information in such a way that dd-agent-java can read the headers and set the traceID and parentID on that span.
- I've also added `finish`, which stops the active span and closes the tracer scope opened by `startSpan`. `finish` is a noop if no span has been started. For the time being, users still must instantiate a `new DDLambda([request, ]context)` in order to start a span and call `DDLambda.finish()` in order to finish the span.
- I've also added a `checkTraceEnabled` function that checks the environment variables to see if the user has set `DD_TRACE_ENABLED` to true or not.

I'm intentionally not updating the README since we're keeping the dd-agent-java lambda layer private for now. Will update the README with documentation once we choose to GA dd-agent-java.

Does not include logic to merge x-ray traces yet.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
