### PR TITLE
Deprecate old HTTP wrapping methods and add instructions for installing dd-trace-java.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ to the Datadog API.
 
 ## Installation
 
-This library will be distributed through JFrog [Bintray](https://bintray.com/beta/#/datadog/datadog-maven/datadog-lambda-java). Follow the [installation instructions](https://docs.datadoghq.com/serverless/installation/java/), and view your function's enhanced metrics, traces and logs in Datadog. 
+This library will be distributed through JFrog [Bintray](https://bintray.com/beta/#/datadog/datadog-maven/datadog-lambda-java). 
+Follow the [installation instructions](https://docs.datadoghq.com/serverless/installation/java/), and view your function's enhanced metrics, traces and logs in Datadog. 
 
 ## Environment Variables
 
@@ -44,14 +45,22 @@ The [Java Tracer](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?
 is an optional component that allows you to trace the execution of your Java Lambda function. 
 The traces will be viewable from your Serverless function details page within Datadog.
 
+Briefly, in order to use the Java tracer, the following prerquisites must be met (detailed below):
+1. The `datadog-lambda-java` library must be included in your project, following these  [installation instructions](https://docs.datadoghq.com/serverless/installation/java/)
+1. You must use a compatible Java runtime
+1. You must attach the Java Tracer lambda layer
+1. Several environment variables must be set
+1. Your handler must instantiate a `new DDLambda` in order to start traces, and call `DDLambda#finish` in order to end traces.
+ 
+
 ### Cold start considerations
 
 The Java Tracer adds a nontrivial cold start penalty. 
-Expect roughly 6 seconds per cold start if your lambda function is configured with 3008MB of memory.
+Expect roughly 6 seconds per cold start if your Lambda function is configured with 3008MB of memory.
 Lambda runtime CPU scales with the amount of memory allocated, so allocating more memory may  help alleviate cold start issues.
 Also consider using provisioned concurrency to keep your lambda function warm.
 
-### Compatable Java runtimes
+### Compatible Java runtimes
 
 - java8.al2 (aka Java 8 (Corretto))
 - java11 (aka Java 11 (Corretto))
@@ -64,6 +73,8 @@ It's called java8.al2 if you're editing serverless.yaml.
 ```
 arn:aws:lambda:[REGION]:464622532012:layer:dd-trace-java:2
 ```
+
+The lambda layer version (in this case, `2`) will always correspond with the minor version of the `datadog-lambda-java` library.
 
 ### Required environment variables for the Java Tracer
 
@@ -119,7 +130,7 @@ If you are using a different event with trace context, you may choose to create 
 ## Downstream Requests
 
 The dd-trace-java tracer will automatically add trace context to outgoing requests for a number of popular services. 
-The list of instrument services can be found here: https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/java/ .
+The list of instrumented services can be found here: https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/java/ .
 If you wish to enable a beta integration, please note that you must do so using an environment variable.
 
 # Trace/Log Correlation

--- a/README.md
+++ b/README.md
@@ -72,21 +72,24 @@ For raw formatted logs, you must update your log format and your log parser. Ins
 
 ### Log Format
 
-If you are using raw formatted logs, update your formatter to include `dd.trace_id` and `dd.span_id`. E.g.
+If you are using raw formatted logs, update your formatter to include `dd.trace_context`. E.g.
 
 ```xml
-<Pattern>"%d{yyyy-MM-dd HH:mm:ss} <%X{AWSRequestId}> %-5p %c:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n"</Pattern>
-<!--Please note:                      Request ID                        Trace ID        Span ID  -->
+<Pattern>"%d{yyyy-MM-dd HH:mm:ss} <%X{AWSRequestId}> %-5p %c:%L %X{dd.trace_context} %m%n"</Pattern>
+<!--Please note:                      Request ID                      Trace Context  -->
 ```
 
 Please note that `RequestId` has also been added. 
-This is not strictly necessary for Trace/Log correlation, but it is useful for correlating logs and invocations.
+RequestId is not strictly necessary for Trace/Log correlation, but it is useful for correlating logs and invocations.
 
 
 ### Grok Parser
 
-The following grok parser parses Java logs generated with `System.out.println`
+The following grok parser parses Java logs formatted using the pattern in the previous section.
 
+```
+java_tracer %{date("yyyy-MM-dd HH:mm:ss"):timestamp}\s\<%{uuid:lambda.request_id}\>\s%{word:level}\s+%{data:call_site}%{_trace_context}%{data:message}
+```
 
 ## Opening Issues
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It's called java8.al2 if you're editing serverless.yaml.
 ### Required Lambda Layer containing the Java Tracer
 
 ```
-arn:aws:lambda:[REGION]:464622532012:layer:dd-trace-java:1
+arn:aws:lambda:[REGION]:464622532012:layer:dd-trace-java:2
 ```
 
 ### Required environment variables for the Java Tracer

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.0.11'
+version= '0.2.0'
 
 allprojects {
     repositories {

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -222,6 +222,7 @@ public class DDLambda {
         }
 
         //to make life easier for people using JSON logging
+        //this is a noop if the tracer is already installed.
         MDC.put(JSON_TRACE_ID, traceId);
         MDC.put(JSON_SPAN_ID, spanId);
         MDC.put(MDC_TRACE_CONTEXT_FIELD, getTraceContextString());

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -12,6 +12,7 @@ import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
+import datadog.trace.api.CorrelationIdentifier;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
@@ -298,6 +299,9 @@ public class DDLambda {
     }
 
     /**
+     * Installing dd-java-agent in your lambda environment automatically wraps outbound HTTP calls.
+     * This is no longer necessary.
+     *
      * openConnection calls openConnection on the provided URL, adds the Datadog trace headers, and then returns the
      * resulting URLConnection. This duplicates the usual workflow with a java.net.URLConnection
      *
@@ -305,6 +309,7 @@ public class DDLambda {
      * @return a newly opened URLConnection with Datadog trace headers.
      * @throws IOException
      */
+    @Deprecated
     public URLConnection makeUrlConnection(URL url) throws IOException {
         URLConnection uc = url.openConnection();
         return addTraceHeaders(uc);
@@ -312,11 +317,15 @@ public class DDLambda {
 
 
     /**
+     * Installing dd-java-agent in your lambda environment automatically wraps outbound HTTP calls.
+     * This is no longer necessary.
+     *
      * Adds Datadog trace headers to a java.net.URLConnection, so you can trace downstream HTTP requests.
      *
      * @param urlConnection the URLConnection that will have the trace headers added to it.
      * @return Returns a mutated URLConnection with the new trace headers.
      */
+    @Deprecated
     public URLConnection addTraceHeaders(URLConnection urlConnection) {
         if (this.tracing == null) {
             DDLogger.getLoggerImpl()
@@ -331,12 +340,16 @@ public class DDLambda {
     }
 
     /**
+     * Installing dd-java-agent in your lambda environment automatically wraps outbound HTTP calls.
+     * This is no longer necessary.
+     *
      * Creates an Apache HttpGet instrumented with Datadog trace headers. Please note, this does not _execute_ the HttpGet,
      * it merely creates a default HttpGet with headers added.
      *
      * @param url The URL that will eventually be gotten.
      * @return Returns an HttpGet for the provided URL, instrumented with Datadog trace headers.
      */
+    @Deprecated
     public HttpGet makeHttpGet(String url) {
         HttpGet hg = new HttpGet(url);
         hg = (HttpGet) addTraceHeaders(hg);
@@ -344,11 +357,15 @@ public class DDLambda {
     }
 
     /**
+     * Installing dd-java-agent in your lambda environment automatically wraps outbound HTTP calls.
+     * This is no longer necessary.
+     *
      * Adds Datadog trace header to an org.apache.http.client.methods.HttpUriRequest, so you can trace downstream HTTP requests.
      *
      * @param httpRequest the HttpUriRequest that will have the trace headers added to it.
      * @return Returns a mutated HttpUriRequest with the new trace headers.
      */
+    @Deprecated
     public HttpUriRequest addTraceHeaders(HttpUriRequest httpRequest) {
         if (this.tracing == null) {
             DDLogger.getLoggerImpl()
@@ -363,10 +380,14 @@ public class DDLambda {
     }
 
     /**
+     * Installing dd-java-agent in your lambda environment automatically wraps outbound HTTP calls.
+     * This is no longer necessary.
+     *
      * Create an OKHttp3 request builder with Datadog headers already added.
      *
      * @return Returns an OKHttp3 Request Builder with Datadog trace headers already added.
      */
+    @Deprecated
     public Request.Builder makeRequestBuilder() {
         Request.Builder hrb = new Request.Builder();
 
@@ -376,11 +397,15 @@ public class DDLambda {
     }
 
     /**
+     * Installing dd-java-agent in your lambda environment automatically wraps outbound HTTP calls.
+     * This is no longer necessary.
+     *
      * Adds Datadog trace header to an OKHttp3 request, so you can trace downstream HTTP requests.
      *
      * @param request The OKHttp3 Request that will have the trace headers added to it.
      * @return Returns a mutated OKHttp3 Request with the new trace headers.
      */
+    @Deprecated
     public Request addTraceHeaders(Request request) {
         if (this.tracing == null) {
             DDLogger.getLoggerImpl()

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -10,6 +10,7 @@ import java.util.Random;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2ProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.google.gson.Gson;
+import datadog.trace.api.CorrelationIdentifier;
 
 public class Tracing{
 
@@ -62,20 +63,28 @@ public class Tracing{
     }
 
     public Map<String,String> getLogCorrelationTraceAndSpanIDsMap(){
-        if (this.cxt != null){
-            String traceID = this.cxt.getTraceID();
-            String spanID = this.cxt.getParentID();
+        String traceId = String.valueOf(CorrelationIdentifier.getTraceId());
+        String spanId = String.valueOf(CorrelationIdentifier.getSpanId());
+        if (traceId != null && !traceId.equals("")){
             Map<String, String> out  = new HashMap<String, String>();
-            out.put(TRACE_ID_KEY, traceID);
-            out.put(SPAN_ID_KEY, spanID);
+            out.put(TRACE_ID_KEY, traceId);
+            out.put(SPAN_ID_KEY, spanId);
+            return out;
+        }
+        if (this.cxt != null){
+            traceId = this.cxt.getTraceID();
+            spanId = this.cxt.getParentID();
+            Map<String, String> out  = new HashMap<String, String>();
+            out.put(TRACE_ID_KEY, traceId);
+            out.put(SPAN_ID_KEY, spanId);
             return out;
         }
         if (this.xrt != null){
-            String traceID = this.xrt.getAPMTraceID();
-            String spanID = this.xrt.getAPMParentID();
+            traceId = this.xrt.getAPMTraceID();
+            spanId = this.xrt.getAPMParentID();
             Map<String, String> out  = new HashMap<String, String>();
-            out.put(TRACE_ID_KEY, traceID);
-            out.put(SPAN_ID_KEY, spanID);
+            out.put(TRACE_ID_KEY, traceId);
+            out.put(SPAN_ID_KEY, spanId);
             return out;
         }
         DDLogger.getLoggerImpl().debug("No DD trace context or XRay trace context set!");

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -65,7 +65,7 @@ public class Tracing{
     public Map<String,String> getLogCorrelationTraceAndSpanIDsMap(){
         String traceId = String.valueOf(CorrelationIdentifier.getTraceId());
         String spanId = String.valueOf(CorrelationIdentifier.getSpanId());
-        if (traceId != null && !traceId.equals("")){
+        if (traceId != null && ! (traceId.equals("") || traceId.equals("0") )){
             Map<String, String> out  = new HashMap<String, String>();
             out.put(TRACE_ID_KEY, traceId);
             out.put(SPAN_ID_KEY, spanId);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Adds installation instructions for the Java tracer. Marks some functions deprecated that the tracer does better.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
