### PR TITLE
Change function_arn to lower case, set resource.name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '0.2.0'
+version= '0.2.1'
 
 allprojects {
     repositories {

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -190,11 +190,12 @@ public class DDLambda {
         if (spanBuilder != null) {
             spanBuilder.withTag("request_id", requestId);
             spanBuilder.withTag("service", "aws.lambda");
-            spanBuilder.withTag("function_arn", functionArn);
+            spanBuilder.withTag("function_arn", functionArn.toLowerCase());
             spanBuilder.withTag("cold_start", ColdStart.getColdStart(cxt));
             spanBuilder.withTag("datadog_lambda", BuildConfig.datadog_lambda_version);
             spanBuilder.withTag("resource_names", functionName);
             spanBuilder.withTag("function_version", functionVersion);
+            spanBuilder.withTag("resource.name", functionName);
         }
         return spanBuilder;
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This changes two tags coming out of the tracer:
- `function_arn` is set to lower case so that the trace will be searchable by the function detail page
- `resource.name` is added -- this is a hack to set `resource` on the root span, since OpenTracing has no concept of `resource`.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
