### PR TITLE
Fix NPE when calling DDLambda

### DIFF
--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -11,6 +11,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import datadog.trace.api.CorrelationIdentifier;
 
@@ -50,7 +51,7 @@ public class DDLambda {
         this.enhanced = checkEnhanced();
         recordEnhanced(INVOCATION, cxt);
         addTraceContextToMDC();
-        startSpan(null, cxt);
+        startSpan(new HashMap<>(), cxt);
     }
 
     /**
@@ -64,7 +65,7 @@ public class DDLambda {
         this.enhanced = checkEnhanced();
         recordEnhanced(INVOCATION, cxt);
         addTraceContextToMDC();
-        startSpan(null, cxt);
+        startSpan(new HashMap<>(), cxt);
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

When calling DDLambda(context) the following exception is thrown
```
java.lang.NullPointerException: java.lang.NullPointerExceptionjava.lang.NullPointerException
at io.opentracing.propagation.TextMapExtractAdapter.iterator(TextMapExtractAdapter.java:38)
at datadog.trace.bootstrap.instrumentation.api.ContextVisitors$EntrySetContextVisitor.forEachKey(ContextVisitors.java:55)
at datadog.trace.bootstrap.instrumentation.api.ContextVisitors$EntrySetContextVisitor.forEachKey(ContextVisitors.java:49)
at datadog.trace.agent.core.propagation.TagContextExtractor.extract(TagContextExtractor.java:27)
at datadog.trace.agent.core.propagation.HttpCodec$CompoundExtractor.extract(HttpCodec.java:97)
at datadog.trace.agent.core.CoreTracer.extract(CoreTracer.java:405)
at datadog.trace.instrumentation.opentracing32.OTTracer.extract(OTTracer.java:68)
at io.opentracing.util.GlobalTracer.extract(GlobalTracer.java:204)
at com.datadoghq.datadog_lambda_java.DDLambda.startSpan(DDLambda.java:139)
at com.datadoghq.datadog_lambda_java.DDLambda.<init>(DDLambda.java:53)
```

This was fixed by applying the fix recommended in https://github.com/DataDog/datadog-lambda-java/issues/34.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Deploying a production Kotlin Lambda that I'd like to trace.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
