### PR TITLE
Add support for SQSEvents

### DIFF
--- a/src/main/java/com/datadoghq/datadog_lambda_java/SQSHeaderable.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/SQSHeaderable.java
@@ -1,0 +1,51 @@
+package com.datadoghq.datadog_lambda_java;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * SQSHeaderable extracts DD's attributes from SQS Events. The conventions are mirrored to those
+ * defined in datadog-lambda-js library. 
+ */
+public class SQSHeaderable implements Headerable {
+
+    static final String DATADOG_ATTRIBUTE_NAME = "_datadog";
+    private static final Type HEADERS_GSON_TYPE =  new TypeToken<Map<String, String>>(){}.getType();
+
+    private Map<String, String> headers;
+
+    /**
+     * Given an SQS Event without any records or datadog attributes produces an empty Headerable.
+     * Otherwise - look up the first record and extract the attributes from it. 
+     * @param event SQS Event
+     */
+    public SQSHeaderable(SQSEvent event) {
+        if (event != null &&
+                (event.getRecords() != null) &&
+                !event.getRecords().isEmpty() &&
+                (event.getRecords().get(0).getMessageAttributes() != null) &&
+                !event.getRecords().get(0).getMessageAttributes().isEmpty() &&
+                !(event.getRecords().get(0).getMessageAttributes().get(DATADOG_ATTRIBUTE_NAME) == null)) {
+            String datadogAttribute = event.getRecords().get(0).getMessageAttributes().get(DATADOG_ATTRIBUTE_NAME)
+                    .getStringValue();
+            Gson g = new Gson();
+            this.headers = g.fromJson(datadogAttribute, HEADERS_GSON_TYPE);
+        } else {
+            this.headers = Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+}

--- a/src/test/java/com/datadoghq/datadog_lambda_java/SQSHeaderableTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/SQSHeaderableTest.java
@@ -1,0 +1,65 @@
+package com.datadoghq.datadog_lambda_java;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertTrue;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.MessageAttribute;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SQSHeaderableTest {
+
+    @Test
+    public void testParsingNullSQSEvent_returnsEmptyHeaders() {
+        Map<String, String> headers = new SQSHeaderable(null).getHeaders();
+
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    public void testParsingSQSEventNoRecords_returnsEmptyHeaders() {
+        SQSEvent event = new SQSEvent();
+
+        Map<String, String> headers = new SQSHeaderable(event).getHeaders();
+
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    public void testParsingSQSEventFirstRecordHasNoDatadogAttributes_returnsEmptyHeaders() {
+        SQSEvent event = new SQSEvent();
+        event.setRecords(singletonList(new SQSMessage()));
+
+        Map<String, String> headers = new SQSHeaderable(event).getHeaders();
+
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    public void testParsingSQSEventWithRecordWithDatadogAttributes_returnsHeaders() {
+        SQSEvent event = new SQSEvent();
+        SQSMessage message = new SQSMessage();
+        Map<String, MessageAttribute> attributes = new HashMap<>();
+        MessageAttribute datadogMessageAttribute = new MessageAttribute();
+        datadogMessageAttribute.setStringValue("{\"x-datadog-trace-id\": \"123\","
+                + "\"x-datadog-parent-id\": \"456\","
+                + "\"x-datadog-sampling-priority\": \"2\"}");
+        attributes.put(SQSHeaderable.DATADOG_ATTRIBUTE_NAME, datadogMessageAttribute);
+        message.setMessageAttributes(attributes);
+        event.setRecords(singletonList(message));
+
+        Map<String, String> headers = new SQSHeaderable(event).getHeaders();
+
+        Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("x-datadog-trace-id", "123");
+        expectedHeaders.put("x-datadog-parent-id", "456");
+        expectedHeaders.put("x-datadog-sampling-priority", "2");
+
+        Assert.assertEquals(expectedHeaders, headers);
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?

Adds support for SQS Events handling. The support's logic (like looking at the first record in the event) is similar to the implementation in https://github.com/DataDog/datadog-lambda-js

### Motivation

We need this direly to be able to trace our lambdas that are triggered by SQS.

### Testing Guidelines

I wrote a unit-test.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
