### PR TITLE
Publish to Sonatype / Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Slack](https://chat.datadoghq.com/badge.svg?bg=632CA6)](https://chat.datadoghq.com/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DataDog/datadog-lambda-java/blob/main/LICENSE)
 ![](https://github.com/DataDog/datadog-lambda-java/workflows/Test%20on%20Master%20branch/badge.svg)
-![Bintray](https://img.shields.io/bintray/v/datadog/datadog-maven/datadog-lambda-java)
+![Maven Central](https://img.shields.io/maven-central/v/com.datadoghq/datadog-lambda-java)
 
 The Datadog Lambda Java Client Library for Java (8 and 11) enables [enhanced lambda metrics](https://docs.datadoghq.com/integrations/amazon_lambda/?tab=awsconsole#real-time-enhanced-lambda-metrics) 
 and [distributed tracing](https://docs.datadoghq.com/integrations/amazon_lambda/?tab=awsconsole#tracing-with-datadog-apm) 
@@ -14,7 +14,7 @@ to the Datadog API.
 
 ## Installation
 
-This library will be distributed through JFrog [Bintray](https://bintray.com/beta/#/datadog/datadog-maven/datadog-lambda-java). 
+This library will be distributed through [Maven Central](https://search.maven.org/artifact/com.datadoghq/datadog-lambda-java). 
 Follow the [installation instructions](https://docs.datadoghq.com/serverless/installation/java/), and view your function's enhanced metrics, traces and logs in Datadog. 
 
 ## Environment Variables

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,9 @@ plugins {
     // Apply the java-library plugin to add support for Java Library
     id 'java-library'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id "com.jfrog.bintray" version "1.8.4"
     id("com.github.gmazzo.buildconfig") version '2.0.2'
+    id 'signing'
+    id 'maven'
 }
 
 repositories {
@@ -47,14 +48,13 @@ targetCompatibility = 1.8
 
 group = 'com.datadoghq'
 version= '0.2.3'
+archivesBaseName = "datadog-lambda-java"
+description = "datadog-lambda-java"
 
 allprojects {
-    repositories {
-        jcenter()
-    }
-    apply plugin: 'maven'
-    apply plugin: 'maven-publish'
-    apply plugin: 'java'
+        apply plugin: 'maven'
+        apply plugin: 'maven-publish'
+        apply plugin: 'java'
 }
 
 publishing {
@@ -68,25 +68,71 @@ publishing {
     }
 }
 
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_TOKEN')
-    publications = ['MyPublication']
-    pkg {
-        repo = 'datadog-maven'
-        name = 'datadog-lambda-java'
-        userOrg = 'datadog'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/DataDog/datadog-lambda-java.git'
-        version {
-            name = project.version.toString()
-            desc = 'Datadog Lambda Java runtime library'
-            vcsTag = project.version.toString()
-            attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
-        }
-    }
-}
 
 buildConfig {
     buildConfigField('String', 'datadog_lambda_version', '"' + project.version.toString() + '"')
+}
+
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+                name 'Datadog Lambda Java library'
+                packaging 'jar'
+                // optionally artifactId can be defined here
+                description 'A library for instrumenting your AWS Lambda functions written in Java and sending the telemetry to Datadog'
+                url 'http://datadoghq.com'
+
+                scm {
+                    connection 'scm:git@github.com:DataDog/datadog-lambda-java.git'
+                    developerConnection 'scm:git@github.com:DataDog/datadog-lambda-java.git'
+                    url 'https://github.com/DataDog/datadog-lambda-java'
+                }
+
+                licenses {
+                    license {
+                        name 'The Apache License, Version 2.0'
+                        url 'https://github.com/DataDog/datadog-lambda-java/blob/main/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'agocs'
+                        name 'Christopher Agocs'
+                        email 'chris.agocs@datadoghq.com'
+                    }
+                }
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,11 +98,11 @@ uploadArchives {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
             }
 
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
             }
 
             pom.project {
@@ -127,9 +127,9 @@ uploadArchives {
 
                 developers {
                     developer {
-                        id 'agocs'
-                        name 'Christopher Agocs'
-                        email 'chris.agocs@datadoghq.com'
+                        id 'serverless'
+                        name 'Datadog Serverless Team'
+                        email 'support@datadoghq.com'
                     }
                 }
             }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

This modifies build.gradle so that datadog-lambda-java gets uploaded to oss.Sonatype.org and then distributed to Maven Central. It also modifies the README to reference the new Maven Central repository as opposed to the old Bintray repository.

### Motivation

<!--- What inspired you to submit this pull request? --->

JFrog is shutting down Bintray on May 1

### Testing Guidelines

<!--- How did you test this pull request? --->

I published v0.2.3 to Maven Central and verified that I could build an example lambda from there.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
