### PR TITLE
Support for the extension - Add hello and flush routes and metric support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation 'com.amazonaws:aws-java-sdk-kinesis:1.11.980'
 
+    // Use wiremock for stubing http calls
+    testCompile 'com.github.tomakehurst:wiremock-jre8:2.31.0'
 }
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ dependencies {
     implementation 'org.jetbrains:annotations:15.0'
     implementation 'io.opentracing:opentracing-api:0.33.0'
     implementation 'io.opentracing:opentracing-util:0.33.0'
-    implementation 'com.datadoghq:dd-trace-api:0.72.0'
+    implementation 'com.datadoghq:dd-trace-api:0.89.0'
+    implementation 'com.datadoghq:java-dogstatsd-client:2.13.0'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation 'com.amazonaws:aws-java-sdk-kinesis:1.11.980'
 
-    // Use wiremock for stubing http calls
+    // Use wiremock for stubbing http calls
     testCompile 'com.github.tomakehurst:wiremock-jre8:2.31.0'
 }
 

--- a/src/main/java/com/datadoghq/datadog_lambda_java/CustomMetric.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/CustomMetric.java
@@ -56,6 +56,18 @@ public class CustomMetric {
         MetricWriter writer = MetricWriter.getMetricWriterImpl();
         writer.write(this);
     }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public double getValue() {
+        return this.value;
+    }
+
+    public Map<String, Object> getTags() {
+        return this.tags;
+    }
 }
 
 class PersistedCustomMetric{

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -364,9 +364,8 @@ public class DDLambda {
         if (this.enhanced) {
             metricName = ENHANCED_PREFIX + basename;
             tags = EnhancedMetric.makeTagsFromContext(cxt);
+            new CustomMetric(metricName, 1, tags).write();
         }
-
-        new CustomMetric(metricName, 1, tags).write();
     }
 
     /**

--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -50,6 +50,11 @@ public class DDLambda {
      */
     private DDLambda() {
         this.shouldUseExtension = Extension.setup();
+        if(this.shouldUseExtension) {
+            DDLogger.getLoggerImpl().debug("Setting the writer to extension");
+            ExtensionMetricWriter emw = new ExtensionMetricWriter();
+            MetricWriter.setMetricWriter(emw);
+        }
     }
 
     /**
@@ -360,6 +365,7 @@ public class DDLambda {
             metricName = ENHANCED_PREFIX + basename;
             tags = EnhancedMetric.makeTagsFromContext(cxt);
         }
+
         new CustomMetric(metricName, 1, tags).write();
     }
 

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
@@ -26,18 +26,18 @@ class Extension {
         return shouldUseExtension;
     }
 
-    public static void flush() {
+    protected static void flush() {
         if(!hitFlushRoute(AGENT_URL, FLUSH_PATH)) {
             DDLogger.getLoggerImpl().debug("Could not call the flush routeg");
         }
     }
 
-    public static boolean isExtensionRunning(final String extensionPath) {
+    protected static boolean isExtensionRunning(final String extensionPath) {
         File f = new File(extensionPath);
         return (f.exists() && !f.isDirectory());
     }
 
-    public static boolean hitHelloRoute(final String agentUrl, final String helloPath) {
+    protected static boolean hitHelloRoute(final String agentUrl, final String helloPath) {
         try {
             URL url = new URL(agentUrl + helloPath);
             HttpURLConnection http = (HttpURLConnection) url.openConnection();
@@ -49,7 +49,7 @@ class Extension {
         }
     }
 
-    public static boolean hitFlushRoute(final String agentUrl, final String flushPath) {
+    protected static boolean hitFlushRoute(final String agentUrl, final String flushPath) {
         try {
             URL url = new URL(agentUrl + flushPath);
             HttpURLConnection http = (HttpURLConnection) url.openConnection();

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
@@ -1,0 +1,65 @@
+package com.datadoghq.datadog_lambda_java;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+class Extension {
+
+    private final static String AGENT_URL = "http://127.0.0.1:8124";
+    private final static String HELLO_PATH = "/lambda/hello";
+    private final static String FLUSH_PATH = "/lambda/flush";
+    private final static String EXTENSION_PATH = "/opt/extensions/datadog-agent";
+
+    public static boolean setup() {
+        boolean shouldUseExtension = false;
+        if(isExtensionRuning(EXTENSION_PATH)) {
+            DDLogger.getLoggerImpl().debug("Extension has been detected");
+            if(hitHelloRoute(AGENT_URL, FLUSH_PATH)) {
+                shouldUseExtension = true;
+            } else {
+                DDLogger.getLoggerImpl().debug("Impossible to call the hello route");
+            }
+        }
+        return shouldUseExtension;
+    }
+
+    public static void flush() {
+        if(!hitFlushRoute(AGENT_URL, FLUSH_PATH)) {
+            DDLogger.getLoggerImpl().debug("Impossible to flush");
+        }
+    }
+
+    public static boolean isExtensionRuning(final String extensionPath) {
+        File f = new File(extensionPath);
+        return (f.exists() && !f.isDirectory());
+    }
+
+    public static boolean hitHelloRoute(final String agentUrl, final String helloPath) {
+        try {
+            URL url = new URL(agentUrl + helloPath);
+            HttpURLConnection http = (HttpURLConnection) url.openConnection();
+            return http.getResponseCode() == HttpURLConnection.HTTP_OK;
+        } catch (MalformedURLException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public static boolean hitFlushRoute(final String agentUrl, final String flushPath) {
+        try {
+            URL url = new URL(agentUrl + flushPath);
+            HttpURLConnection http = (HttpURLConnection) url.openConnection();
+            http.setRequestMethod("POST");
+            return http.getResponseCode() == HttpURLConnection.HTTP_OK;
+        } catch (MalformedURLException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
@@ -13,7 +13,7 @@ class Extension {
     private final static String FLUSH_PATH = "/lambda/flush";
     private final static String EXTENSION_PATH = "/opt/extensions/datadog-agent";
 
-    public static boolean setup() {
+    protected static boolean setup() {
         boolean shouldUseExtension = false;
         if(isExtensionRunning(EXTENSION_PATH)) {
             DDLogger.getLoggerImpl().debug("Extension has been detected");

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
@@ -17,7 +17,7 @@ class Extension {
         boolean shouldUseExtension = false;
         if(isExtensionRuning(EXTENSION_PATH)) {
             DDLogger.getLoggerImpl().debug("Extension has been detected");
-            if(hitHelloRoute(AGENT_URL, FLUSH_PATH)) {
+            if(hitHelloRoute(AGENT_URL, HELLO_PATH)) {
                 shouldUseExtension = true;
             } else {
                 DDLogger.getLoggerImpl().debug("Impossible to call the hello route");

--- a/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Extension.java
@@ -15,12 +15,12 @@ class Extension {
 
     public static boolean setup() {
         boolean shouldUseExtension = false;
-        if(isExtensionRuning(EXTENSION_PATH)) {
+        if(isExtensionRunning(EXTENSION_PATH)) {
             DDLogger.getLoggerImpl().debug("Extension has been detected");
             if(hitHelloRoute(AGENT_URL, HELLO_PATH)) {
                 shouldUseExtension = true;
             } else {
-                DDLogger.getLoggerImpl().debug("Impossible to call the hello route");
+                DDLogger.getLoggerImpl().debug("Could not call the hello route");
             }
         }
         return shouldUseExtension;
@@ -28,11 +28,11 @@ class Extension {
 
     public static void flush() {
         if(!hitFlushRoute(AGENT_URL, FLUSH_PATH)) {
-            DDLogger.getLoggerImpl().debug("Impossible to flush");
+            DDLogger.getLoggerImpl().debug("Could not call the flush routeg");
         }
     }
 
-    public static boolean isExtensionRuning(final String extensionPath) {
+    public static boolean isExtensionRunning(final String extensionPath) {
         File f = new File(extensionPath);
         return (f.exists() && !f.isDirectory());
     }

--- a/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
@@ -5,9 +5,17 @@ package com.datadoghq.datadog_lambda_java;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -41,6 +49,46 @@ public class CustomMetricTest {
 
         assertNotNull(smw.getMetricsWritten());
         assertEquals("{\"m\":\"foo\",\"v\":24.3,\"t\":[],\"e\":1559152800}",smw.getMetricsWritten());
+    }
+
+    @Test public void testExtensionMetricWriter() {
+        Map<String, Object> map = new LinkedHashMap<>(); // to save the order to avoid flaky test
+        map.put("firstTag", "firstTagValue");
+        map.put("secondTag", 100.34);
+        CustomMetric ddm = new CustomMetric("foo", 24.3, map);
+        ExtensionMetricWriter emw = new ExtensionMetricWriter();
+        MetricWriter.setMetricWriter(emw);
+        final String[] text = new String[1];
+
+        new Thread(new Runnable() {
+            public void run() {
+                byte[] msg = new byte[256];
+                DatagramPacket dp = new DatagramPacket(msg, msg.length);
+                DatagramSocket ds = null;
+                try {
+                    ds = new DatagramSocket(8125);
+                    ds.receive(dp);
+                    text[0] = new String(dp.getData());
+                } catch (SocketException e) {
+                    e.printStackTrace();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                } finally {
+                    if (ds != null) {
+                        ds.close();
+                    }
+                }
+            }
+        }).start();
+
+        ddm.write();
+
+        try {
+            Thread.sleep(1000);
+            assertTrue(text[0].startsWith("foo:24.3|d|#firsttag:firsttagvaluesecondtag:100.34"));
+        } catch (InterruptedException e) {
+            fail();
+        }
     }
 
     /**

--- a/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
@@ -87,7 +87,7 @@ public class CustomMetricTest {
         int i = 0;
         for(; i < 10; ++i) {
             try {
-                if (text[0].equals("notYetReceived")) {
+                if (null== text[0] || text[0].equals("notYetReceived")) {
                     Thread.sleep(1000);
                 } else {
                     assertTrue(text[0].startsWith("foo:24.3|d|#firsttag:firsttagvaluesecondtag:100.34"));

--- a/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
@@ -66,6 +66,7 @@ public class CustomMetricTest {
                 DatagramPacket dp = new DatagramPacket(msg, msg.length);
                 DatagramSocket ds = null;
                 try {
+                    text[0] = "notYetReceived";
                     ds = new DatagramSocket(8125);
                     ds.receive(dp);
                     text[0] = new String(dp.getData());
@@ -83,10 +84,20 @@ public class CustomMetricTest {
 
         ddm.write();
 
-        try {
-            Thread.sleep(1000);
-            assertTrue(text[0].startsWith("foo:24.3|d|#firsttag:firsttagvaluesecondtag:100.34"));
-        } catch (InterruptedException e) {
+        int i = 0;
+        for(; i < 10; ++i) {
+            try {
+                if (text[0].equals("notYetReceived")) {
+                    Thread.sleep(1000);
+                } else {
+                    assertTrue(text[0].startsWith("foo:24.3|d|#firsttag:firsttagvaluesecondtag:100.34"));
+                    break;
+                }
+            } catch (InterruptedException e) {
+                fail();
+            }
+        }
+        if( i == 10) {
             fail();
         }
     }

--- a/src/test/java/com/datadoghq/datadog_lambda_java/ExtensionTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/ExtensionTest.java
@@ -19,11 +19,11 @@ public class ExtensionTest {
     @Test public void testDetectExtensionSuccess() {
         Path resourceDirectory = Paths.get("src","test","resources");
         String fakeExtensionPath = resourceDirectory.toFile().getAbsolutePath() + "/fakeExtension";
-        Assert.assertTrue(Extension.isExtensionRuning(fakeExtensionPath));
+        Assert.assertTrue(Extension.isExtensionRunning(fakeExtensionPath));
     }
     @Test public void testDetectExtensionFailure() {
         String invalidPath = "/fakeExtension";
-        Assert.assertFalse(Extension.isExtensionRuning(invalidPath));
+        Assert.assertFalse(Extension.isExtensionRunning(invalidPath));
     }
 
     @Test public void testHitHelloRouteIncorrectUrl() {

--- a/src/test/java/com/datadoghq/datadog_lambda_java/ExtensionTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/ExtensionTest.java
@@ -1,0 +1,57 @@
+package com.datadoghq.datadog_lambda_java;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+
+public class ExtensionTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(9999);
+
+    @Test public void testDetectExtensionSuccess() {
+        Path resourceDirectory = Paths.get("src","test","resources");
+        String fakeExtensionPath = resourceDirectory.toFile().getAbsolutePath() + "/fakeExtension";
+        Assert.assertTrue(Extension.isExtensionRuning(fakeExtensionPath));
+    }
+    @Test public void testDetectExtensionFailure() {
+        String invalidPath = "/fakeExtension";
+        Assert.assertFalse(Extension.isExtensionRuning(invalidPath));
+    }
+
+    @Test public void testHitHelloRouteIncorrectUrl() {
+        Assert.assertFalse(Extension.hitHelloRoute("toto", "titi"));
+    }
+
+    @Test public void testHitHelloRouteNotRespondingEndpoint() {
+        Assert.assertFalse(Extension.hitHelloRoute("http://localhost:1111", "/invalid"));
+    }
+
+    @Test public void testHitHelloRouteValidEndpoint() {
+        stubFor(get(urlEqualTo("/valid"))
+                .willReturn(aResponse()));
+        Assert.assertTrue(Extension.hitHelloRoute("http://localhost:9999", "/valid"));
+    }
+
+    @Test public void testHitFlushRouteIncorrectUrl() {
+        Assert.assertFalse(Extension.hitFlushRoute("toto", "titi"));
+    }
+
+    @Test public void testHitFlushRouteNotRespondingEndpoint() {
+        Assert.assertFalse(Extension.hitFlushRoute("http://localhost:1111", "/invalid"));
+    }
+
+    @Test public void testHitFlushRouteValidEndpoint() {
+        stubFor(post(urlEqualTo("/valid"))
+                .willReturn(aResponse()));
+        Assert.assertTrue(Extension.hitFlushRoute("http://localhost:9999", "/valid"));
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?

Support the extension by : 
- sending metrics to the extension
- adding the file detection + hello + flush route calls
- heavy dependence on `finish`

- fix a bug where metrics could have been sent even if disabled


<img width="713" alt="Screen Shot 2021-11-01 at 12 56 29 PM" src="https://user-images.githubusercontent.com/864493/139710835-d5852c31-4826-4dfa-8a5c-3eb61d4083a0.png">

<img width="1268" alt="Screen Shot 2021-11-01 at 4 12 56 PM" src="https://user-images.githubusercontent.com/864493/139735456-300f3a4f-8503-4eba-8af3-7a6f287d2f40.png">

### Motivation

Start the extension support/tests without being blocked by the flush removal task.

### Testing Guidelines

Deploy a function, be able to see logs for instance.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
