### PR TITLE
Bump version of log4j-api and log4j-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.apache.logging.log4j:log4j-api:2.14.1'
-    testImplementation 'org.apache.logging.log4j:log4j-core:2.14.1'
+    testImplementation 'org.apache.logging.log4j:log4j-api:2.15.0'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.15.0'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation 'com.amazonaws:aws-java-sdk-kinesis:1.11.980'
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This bumps the versions of log4j-api and log4j-core that were imported for testing. The old versions of log4j were found to be susceptible to a remote code execution attack. See the following resources for more info:

- https://www.lunasec.io/docs/blog/log4j-zero-day/
- https://www.randori.com/blog/cve-2021-44228/
- [CVE-2021-44228](https://www.cve.org/CVERecord?id=CVE-2021-44228)

datadog-lambda-java _only_ uses log4j in testing, and the log4j dependency does not make it into the published library. Regardless, we are going to cut a new version to be safe.   

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
