### PR TITLE
Update aws-lambda-java-log4j2 to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-log4j:1.0.1'
+    implementation 'com.amazonaws:aws-lambda-java-log4j2:1.3.0'
     implementation 'com.amazonaws:aws-lambda-java-events:3.10.0'
     compileOnly 'com.amazonaws:aws-java-sdk-kinesis:1.12.100'
     implementation 'com.google.code.gson:gson:2.8.9'
@@ -52,7 +52,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.datadoghq'
-version= '1.4.0'
+version= '1.4.1'
 archivesBaseName = "datadog-lambda-java"
 description = "datadog-lambda-java"
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Updates the imported version of `aws-lambda-java-log4j2` to 1.3.0 (from `aws-lambda-java-log4j:1.0.1`), per https://aws.amazon.com/security/security-bulletins/AWS-2021-005/. This does not affect the behavior of `datadog-lambda-java`. 

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
