### PR TITLE
Fix tags concatenation in custom metric

### DIFF
--- a/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
@@ -90,7 +90,7 @@ public class CustomMetricTest {
                 if (null == text[0] || text[0].equals("notYetReceived")) {
                     Thread.sleep(1000);
                 } else {
-                    assertTrue(text[0].startsWith("foo:24.3|d|#firsttag:firsttagvaluesecondtag:100.34"));
+                    assertTrue(text[0].startsWith("foo:24.3|d|#firsttag:firsttagvalue,secondtag:100.34"));
                     break;
                 }
             }


### PR DESCRIPTION
### What does this PR do?

Fix concatenated tags for custom metrics.

### Motivation

A bug that prevents from submitting more than 1 tag.
Bugfix for https://github.com/DataDog/datadog-lambda-java/issues/75

### Testing Guidelines

Unit test and test on a real AWS environment with the custom-built jar.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
