### PR TITLE
Bump java-dogstatsd-client from 3.0.0 to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'io.opentracing:opentracing-api:0.33.0'
     implementation 'io.opentracing:opentracing-util:0.33.0'
     implementation 'com.datadoghq:dd-trace-api:0.90.0'
-    implementation 'com.datadoghq:java-dogstatsd-client:3.0.0'
+    implementation 'com.datadoghq:java-dogstatsd-client:4.0.0'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Bump java-dogstatsd-client from version 3.0.0 to version 4.0.0

### Motivation

Looking into possible solutions for #78

### Testing Guidelines

Not tested so far, but according to https://github.com/DataDog/java-dogstatsd-client/releases/tag/v4.0.0 there should be no incompatible API changes:

> This release is a correction for v3.0.0, which was released without client-side aggregation enabled by default.
> 
> There are no incompatible API changes in this release.
> 

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
