### PR TITLE
Simplify dependencies to include on slf4j-api but not the implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'org.slf4j:slf4j-log4j12:1.7.32'
+    implementation 'org.slf4j:slf4j-api:1.7.32'
     implementation 'org.jetbrains:annotations:22.0.0'
     implementation 'io.opentracing:opentracing-api:0.33.0'
     implementation 'io.opentracing:opentracing-util:0.33.0'
@@ -40,6 +40,7 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.13.2'
     //log4j imported for running unit tests. Doesn't get bundled with the build artifact.
+    testImplementation 'org.slf4j:slf4j-log4j12:1.7.32'
     testImplementation 'org.apache.logging.log4j:log4j-api:2.17.1'
     testImplementation 'org.apache.logging.log4j:log4j-core:2.17.1'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove `log4j:log4j:1.2.17` from the project's dependency tree. 

### Motivation

Current dependencies of the project looks like:

```
+--- com.datadoghq:datadog-lambda-java:1.4.4
|    +--- com.amazonaws:aws-lambda-java-core:1.2.1
|    +--- com.amazonaws:aws-lambda-java-events:3.10.0 (*)
|    +--- com.google.code.gson:gson:2.8.9
|    +--- org.apache.httpcomponents:httpclient:4.5.13 (*)
|    +--- com.squareup.okhttp3:okhttp:4.9.2 (*)
|    +--- org.apache.commons:commons-lang3:3.12.0
|    +--- org.slf4j:slf4j-log4j12:1.7.32
|    |    +--- org.slf4j:slf4j-api:1.7.32
|    |    \--- log4j:log4j:1.2.17
|    +--- org.jetbrains:annotations:22.0.0
|    +--- io.opentracing:opentracing-api:0.33.0
|    +--- io.opentracing:opentracing-util:0.33.0
|    |    +--- io.opentracing:opentracing-api:0.33.0
|    |    \--- io.opentracing:opentracing-noop:0.33.0
|    |         \--- io.opentracing:opentracing-api:0.33.0
|    +--- com.datadoghq:dd-trace-api:0.90.0
|    \--- com.datadoghq:java-dogstatsd-client:3.0.0
|         \--- com.github.jnr:jnr-unixsocket:0.36
|              +--- com.github.jnr:jnr-ffi:2.1.16
|              |    +--- com.github.jnr:jffi:1.2.23
|              |    +--- org.ow2.asm:asm:7.1
|              |    +--- org.ow2.asm:asm-commons:7.1
|              |    |    +--- org.ow2.asm:asm:7.1
|              |    |    +--- org.ow2.asm:asm-tree:7.1
|              |    |    |    \--- org.ow2.asm:asm:7.1
|              |    |    \--- org.ow2.asm:asm-analysis:7.1
|              |    |         \--- org.ow2.asm:asm-tree:7.1 (*)
|              |    +--- org.ow2.asm:asm-analysis:7.1 (*)
|              |    +--- org.ow2.asm:asm-tree:7.1 (*)
|              |    +--- org.ow2.asm:asm-util:7.1
|              |    |    +--- org.ow2.asm:asm:7.1
|              |    |    +--- org.ow2.asm:asm-tree:7.1 (*)
|              |    |    \--- org.ow2.asm:asm-analysis:7.1 (*)
|              |    +--- com.github.jnr:jnr-a64asm:1.0.0
|              |    \--- com.github.jnr:jnr-x86asm:1.0.2
|              +--- com.github.jnr:jnr-constants:0.9.17
|              +--- com.github.jnr:jnr-enxio:0.30
|              |    +--- com.github.jnr:jnr-constants:0.9.17
|              |    \--- com.github.jnr:jnr-ffi:2.1.16 (*)
|              \--- com.github.jnr:jnr-posix:3.0.61
|                   +--- com.github.jnr:jnr-ffi:2.1.16 (*)
|                   \--- com.github.jnr:jnr-constants:0.9.17
```

If the project is added as a dependency to any other project that implements slf4j with another binder than log4j (for example - logback) then SLF4J warns about multiple log bindings:

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/ota/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.2.11/4741689214e9d1e8408b206506cbe76d1c6a7d60/logback-classic-1.2.11.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/ota/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-log4j12/1.7.32/1e225e45fd0c339284c7dcd87cc7a92665d6d559/slf4j-log4j12-1.7.32.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
```

This PR addresses the issue by removing log4j from classpath. Please note that the `slf4j-api` depedency is still present, so MDC class is still available for `datadog-lambda-java`. 

### Testing Guidelines

Tests pass

### Additional Notes

Typically, when it comes to logging in library-like dependencies (datadog-lambda-java is library-like) the convention is to include slf4j-api dependency as a facade/interface for logging and let the projects that depend on the library-like dependency choose the implementation of the slf4j api. 

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [] This PR contains breaking changes that are documented in the description
- [] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
