### PR TITLE
Statically initialize MetricWriter and DogStatsD client

### DIFF
--- a/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/DDLambda.java
@@ -52,7 +52,7 @@ public class DDLambda {
         this.shouldUseExtension = Extension.setup();
         if(this.shouldUseExtension) {
             DDLogger.getLoggerImpl().debug("Setting the writer to extension");
-            ExtensionMetricWriter emw = new ExtensionMetricWriter();
+            ExtensionMetricWriter emw = ExtensionMetricWriter.GetInstance();
             MetricWriter.setMetricWriter(emw);
         }
     }

--- a/src/main/java/com/datadoghq/datadog_lambda_java/MetricWriter.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/MetricWriter.java
@@ -39,20 +39,30 @@ class StdoutMetricWriter extends MetricWriter{
 
 class ExtensionMetricWriter extends MetricWriter{
 
-    private StatsDClient client;
+    private static StatsDClient client;
+    private static ExtensionMetricWriter emw;
 
-    public ExtensionMetricWriter() {
-        try {
-            this.client = new NonBlockingStatsDClientBuilder()
-                    .prefix("")
-                    .hostname("127.0.0.1")
-                    .port(8125)
-                    .enableTelemetry(false)
-                    .telemetryFlushInterval(0)
-                    .build();
-        } catch (Exception e) {
-            DDLogger.getLoggerImpl().error("Could not create StatsDClient " + e.getMessage());
-            this.client = null;
+    public static ExtensionMetricWriter GetInstance(){
+        if (null == emw){
+            emw = new ExtensionMetricWriter();
+        }
+        return emw;
+    }
+
+    private ExtensionMetricWriter() {
+        if (null == client) {
+            try {
+                client = new NonBlockingStatsDClientBuilder()
+                        .prefix("")
+                        .hostname("127.0.0.1")
+                        .port(8125)
+                        .enableTelemetry(false)
+                        .telemetryFlushInterval(0)
+                        .build();
+            } catch (Exception e) {
+                DDLogger.getLoggerImpl().error("Could not create StatsDClient " + e.getMessage());
+                client = null;
+            }
         }
     }
 

--- a/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
+++ b/src/test/java/com/datadoghq/datadog_lambda_java/CustomMetricTest.java
@@ -56,7 +56,7 @@ public class CustomMetricTest {
         map.put("firstTag", "firstTagValue");
         map.put("secondTag", 100.34);
         CustomMetric ddm = new CustomMetric("foo", 24.3, map);
-        ExtensionMetricWriter emw = new ExtensionMetricWriter();
+        ExtensionMetricWriter emw = ExtensionMetricWriter.GetInstance();
         MetricWriter.setMetricWriter(emw);
         final String[] text = new String[1];
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes #74 
Statically initialize the ExtensionMetricWriter and the DogStatsD client to avoid leaking threads

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
