### PR TITLE
fix: backport lineage fix to datadog-lambda-java

### DIFF
--- a/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
+++ b/src/main/java/com/datadoghq/datadog_lambda_java/Tracing.java
@@ -373,7 +373,7 @@ class XRayTraceContext{
             return;
         }
         String[] traceParts = traceId.split(";");
-        if(traceParts.length != 3){
+        if(hasInvalidXrayHeader(traceParts)){
             DDLogger.getLoggerImpl().error ("Malformed _X_AMZN_TRACE_ID value: "+ traceId);
             return;
         }
@@ -388,13 +388,17 @@ class XRayTraceContext{
         this.traceIdHeader = traceId;
     }
 
+    private static boolean hasInvalidXrayHeader(String[] traceParts) {
+        return traceParts.length < 3;
+    }
+
     /**
      * Test constructor that can take a dummy _X_AMZN_TRACE_ID value rather than reading from env vars
      * @param traceId
      */
     protected XRayTraceContext(String traceId){
         String[] traceParts = traceId.split(";");
-        if(traceParts.length != 3){
+        if(hasInvalidXrayHeader(traceParts)){
             DDLogger.getLoggerImpl().error("Malformed _X_AMZN_TRACE_ID value: "+ traceId);
             return;
         }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-java/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adopts a patch suggested by @GitMarco, with a slightly renamed method.

### Motivation

Backporting a fix to this library for the new Lineage parameter in the xray trace ID
Fixes #89

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
